### PR TITLE
Tox: use development version of Products.isurlinportal.

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -7,3 +7,5 @@ package-name = Products.isurlinportal
 [versions]
 setuptools = 41.2.0
 zc.buildout = 2.13.3
+# Use development version:
+Products.isurlinportal =

--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,9 @@ setenv =
 [testenv:5.0-py27]
 setenv =
     PLONE_VERSION=5.0
+deps =
+    -rrequirements.txt
+    Pillow==3.3.0
 
 [testenv:5.1-py27]
 setenv =


### PR DESCRIPTION
And in the Plone 5.0 environment, install Pillow with pip.
Locally on my Mac, buildout fails to install it.