### PR TITLE
make `tox.ini` compatible with the upcoming `tox` version 4

### DIFF
--- a/news/7.bugfix.rst
+++ b/news/7.bugfix.rst
@@ -1,0 +1,2 @@
+Make tox.ini compatible with upcoming version 4 of tox.
+[jugmac00]

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ envlist =
 basepython = python2.7
 commands =
     cp {toxinidir}/buildout.cfg {envdir}/buildout.cfg
-    sed -ie "s#test-5.x.cfg#test-{env:PLONE_VERSION}.x.cfg#" {envdir}/buildout.cfg
+    sed -ie "s\#test-5.x.cfg\#test-{env:PLONE_VERSION}.x.cfg\#" {envdir}/buildout.cfg
     {envbindir}/buildout -c {envdir}/buildout.cfg buildout:directory={envdir} buildout:develop={toxinidir} install test
     {envbindir}/test
 skip_install = true

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ envlist =
 basepython = python2.7
 commands =
     cp {toxinidir}/buildout.cfg {envdir}/buildout.cfg
-    sed -ie "s\#test-5.x.cfg\#test-{env:PLONE_VERSION}.x.cfg\#" {envdir}/buildout.cfg
+    sed -ie "s/test-5.x.cfg/test-{env:PLONE_VERSION}.x.cfg/" {envdir}/buildout.cfg
     {envbindir}/buildout -c {envdir}/buildout.cfg buildout:directory={envdir} buildout:develop={toxinidir} install test
     {envbindir}/test
 skip_install = true


### PR DESCRIPTION
`tox4` will support inline comments (#), so they need to be escaped for the `sed` command

Also see https://github.com/tox-dev/tox/issues/1944