### PR TITLE
Return False when a url is not like a string, for example None.

### DIFF
--- a/Products/isurlinportal/__init__.py
+++ b/Products/isurlinportal/__init__.py
@@ -103,9 +103,22 @@ def isURLInPortal(self, url, context=None):
     # site_properties are also considered within the portal to allow for
     # single sign on.
 
-    if len(url.splitlines()) > 1:
+    try:
+        lines = url.splitlines()
+    except AttributeError:
+        # I have seen None getting passed, and this should not give a traceback.
+        # Only string-like values should be considered.
+        # We could check 'isinstance(url, str)', but then you need to think about
+        # py2/3: bytes/str/unicode/text/basestring, and I don't want that.
+        return False
+    if len(lines) > 1:
         # very fishy
         return False
+    if not url:
+        # Redirecting to nothing would probably mean we end up on the same page.
+        # So an empty url should be fine.  This was always the case,
+        # but now we return early.
+        return True
     if url != url.strip():
         # somewhat fishy
         return False

--- a/Products/isurlinportal/tests.py
+++ b/Products/isurlinportal/tests.py
@@ -216,3 +216,16 @@ class TestURLTool(unittest.TestCase):
         iURLiP = url_tool.isURLInPortal
         self.assertFalse(iURLiP("http:example.org"))
         self.assertFalse(iURLiP("https:example.org"))
+
+    def test_bad_type(self):
+        # I have seen None getting passed, giving a traceback.
+        # Only string-like values should be considered.
+        url_tool = self._makeOne()
+        iURLiP = url_tool.isURLInPortal
+        self.assertFalse(iURLiP(None))
+        self.assertFalse(iURLiP(True))
+        self.assertFalse(iURLiP(False))
+        self.assertFalse(iURLiP([self.site.absolute_url()]))
+        self.assertFalse(iURLiP((self.site.absolute_url(),)))
+        self.assertFalse(iURLiP(object()))
+        self.assertFalse(iURLiP(1))

--- a/news/8.bugfix
+++ b/news/8.bugfix
@@ -1,0 +1,3 @@
+Return False when a url is not like a string, for example None.
+Note: this is not a security fix.
+[maurits]


### PR DESCRIPTION
This fixes a traceback when the url is None.
Note: this is not a security fix.
Fixes https://github.com/plone/Products.isurlinportal/issues/8