### PR TITLE
No longer patch Products.CMFPlone.

### DIFF
--- a/.meta.toml
+++ b/.meta.toml
@@ -7,4 +7,6 @@ commit-id = "7a017355"
 
 [pyproject]
 codespell_ignores = "noo"
-dependencies_ignores = "['Products.CMFPlone']"
+
+[tox]
+constraints_file = "https://dist.plone.org/release/6.1-dev/constraints.txt"

--- a/Products/isurlinportal/__init__.py
+++ b/Products/isurlinportal/__init__.py
@@ -2,12 +2,10 @@ from html import unescape
 from plone.base.interfaces import ILoginSchema
 from plone.registry.interfaces import IRegistry
 from posixpath import normpath
-
-# This is the class we will patch:
-from Products.CMFPlone.URLTool import URLTool
 from urllib.parse import urljoin
 from urllib.parse import urlparse
 from zope.component import getUtility
+from ZPublisher import zpublish
 
 import re
 import string
@@ -96,21 +94,20 @@ def get_external_sites(context=None):
     return settings.allow_external_login_sites
 
 
+@zpublish(False)
 def isURLInPortal(self, url, context=None):
-    # Note: no docstring, because the method is publicly available
-    # but does not need to be callable on site-url/portal_url/isURLInPortal.
+    """Check if a given url is on the same host and contains the portal path.
 
-    # Check if a given url is on the same host and contains the portal
-    # path.  Used to ensure that login forms can determine relevant
-    # referrers (i.e. in portal).  Also return true for some relative
-    # urls if context is passed in to allow for url parsing. When context
-    # is not provided, assume that relative urls are in the portal. It is
-    # assumed that http://portal is the same portal as https://portal.
+    This is used to ensure that login forms can determine relevant
+    referrers (i.e. in portal).  Also return true for some relative
+    urls if context is passed in to allow for url parsing. When context
+    is not provided, assume that relative urls are in the portal. It is
+    assumed that http://portal is the same portal as https://portal.
 
-    # External sites listed in 'allow_external_login_sites' of
-    # site_properties are also considered within the portal to allow for
-    # single sign on.
-
+    External sites listed in 'allow_external_login_sites' of
+    site_properties are also considered within the portal to allow for
+    single sign on.
+    """
     try:
         lines = url.splitlines()
     except AttributeError:
@@ -199,7 +196,3 @@ def isURLInPortal(self, url, context=None):
         if host == u_host and u_path.startswith(path):
             return True
     return False
-
-
-# Add our method to the URLTool.
-URLTool.isURLInPortal = isURLInPortal

--- a/news/12.breaking
+++ b/news/12.breaking
@@ -1,0 +1,3 @@
+No longer patch Products.CMFPlone.  Version 6.1.0a5 will use us directly.
+This solves cyclic dependencies, and is incompatible with Plone 6.0.
+[maurits]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,6 @@ Zope = [
   'Products.CMFCore', 'Products.CMFDynamicViewFTI',
 ]
 python-dateutil = ['dateutil']
-ignore-packages = ['Products.CMFPlone']
 
 ##
 # Add extra configuration options in .meta.toml:

--- a/setup.py
+++ b/setup.py
@@ -11,20 +11,19 @@ long_description = readme + "\n" + changes
 
 setup(
     name="Products.isurlinportal",
-    version="2.0.4.dev0",
-    description="Replacement for isURLInPortal method in Plone",
+    version="3.0.0.dev0",
+    description="Implementation of isURLInPortal method in Plone",
     long_description=long_description,
     # Get more strings from https://pypi.org/classifiers/
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Framework :: Plone",
-        "Framework :: Plone :: 6.0",
+        "Framework :: Plone :: 6.1",
         "License :: OSI Approved :: GNU General Public License (GPL)",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
     keywords="plone security hotfix patch",
     author="Plone Security Team",
@@ -35,15 +34,14 @@ setup(
     namespace_packages=["Products"],
     include_package_data=True,
     zip_safe=False,
-    python_requires=">=3.8",
+    python_requires=">=3.10",
     install_requires=[
         "setuptools",
         "plone.base",
-        "zope.component",
+        "Zope>=5.10",
     ],
     extras_require={
         "test": [
-            "Acquisition",
             "Products.CMFPlone",
         ]
     },

--- a/tox.ini
+++ b/tox.ini
@@ -108,7 +108,7 @@ set_env =
 ##
 deps =
     zope.testrunner
-    -c https://dist.plone.org/release/6.0-dev/constraints.txt
+    -c https://dist.plone.org/release/6.1-dev/constraints.txt
 
 ##
 # Specify additional deps in .meta.toml:
@@ -151,7 +151,7 @@ set_env =
 deps =
     coverage
     zope.testrunner
-    -c https://dist.plone.org/release/6.0-dev/constraints.txt
+    -c https://dist.plone.org/release/6.1-dev/constraints.txt
 
 commands =
     coverage run --branch --source Products.isurlinportal {envbindir}/zope-testrunner --quiet --all --test-path={toxinidir} -s Products.isurlinportal {posargs}
@@ -169,7 +169,7 @@ deps =
     twine
     build
     towncrier
-    -c https://dist.plone.org/release/6.0-dev/constraints.txt
+    -c https://dist.plone.org/release/6.1-dev/constraints.txt
 
 commands =
     # fake version to not have to install the package
@@ -200,7 +200,7 @@ allowlist_externals =
 deps =
     pipdeptree
     pipforester
-    -c https://dist.plone.org/release/6.0-dev/constraints.txt
+    -c https://dist.plone.org/release/6.1-dev/constraints.txt
 
 commands =
     # Generate the full dependency tree


### PR DESCRIPTION
Plone 6.1.0a5 will use us directly.
This solves cyclic dependencies, and is incompatible with Plone 6.0.
This fixes https://github.com/plone/Products.isurlinportal/issues/12

Depend on `Zope>=5.10` as we use the new `ZPublisher.zpublish` to explicitly say the `isURLInPortal` should not be published, so should not be available on a URL. Now we can use a docstring again, which feels a bit nicer.

I have updated the coredev buildout 6.0 to use branch 2.x.